### PR TITLE
Empty rooms if no content on pages #61

### DIFF
--- a/snd/image_board/templates/favorites.html
+++ b/snd/image_board/templates/favorites.html
@@ -4,8 +4,13 @@
 {% block body %}
     <div class="content-cont">
         <div class="row">
-            <h2>My favorites page</h2>
+            <h2>{{ request.user }}'s favorites</h2>
             <hr class="line"/>
         </div>
+
+        {% if not user.favorite_set.all %}
+        <H2>Oops, You don't have any Favorites </H2>
+        Please visit <a href="{% url 'index' %}">our page</a> and favorite some memes
+        {% endif %}
     </div>
 {% endblock %}

--- a/snd/image_board/templates/myposts.html
+++ b/snd/image_board/templates/myposts.html
@@ -5,7 +5,7 @@
     {% if user.is_authenticated %}
         <div class="content-cont">
             <div class="row">
-                <h2>Your Uploads</h2>
+                <h2>{{ user }}'s Uploads</h2>
                 <hr class="line"/>
             </div>
             {% include "content_items.html" %}

--- a/snd/image_board/templates/myposts.html
+++ b/snd/image_board/templates/myposts.html
@@ -9,6 +9,10 @@
                 <hr class="line"/>
             </div>
             {% include "content_items.html" %}
+        {% if not user.contentitem_set.all %}
+        <H2>Oops, You don't have any any post, yet! </H2>
+        Please <a href="{% url 'create_post' %}">Create</a> some posts, share and enjoy!!
+        {% endif %}
         </div>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Shows "info"  on following pages, if the page doesn't have any content

- my post

- favorites

and NOT in main page because I believe the main page should always have some content, when it's live.